### PR TITLE
Fix following equation as well

### DIFF
--- a/_published/includes/survival_analysis/body.html
+++ b/_published/includes/survival_analysis/body.html
@@ -390,7 +390,12 @@ h(t) &amp;= \lim_{\Delta t \to 0} Pr(t \leq T \leq t + \Delta t \, | \, T \geq t
        </a>
        :
       </p>
-      $$\hat{S}(t)= \prod_{ti where $d_i$ is the number of events (deaths) observed at time $t_i$ and $n_i$ is the number of subjects at risk observed at time $t_i$.
+      \begin{align*}
+\hat{S}(t) &amp;= \prod_{t_i \leq t} \frac{n_i − d_i}{n_i}\,,
+\end{align*}
+      <p>
+       where $d_i$ is the number of events (deaths) observed at time $t_i$ and $n_i$ is the number of subjects at risk observed at time $t_i$.
+      </p>
      </div>
     </div>
    </div>

--- a/notebooks/survival_analysis/survival_analysis.ipynb
+++ b/notebooks/survival_analysis/survival_analysis.ipynb
@@ -115,7 +115,9 @@
     "\n",
     "In practice, we do not get to observe the actual survival function of a population; we must use the observed data to estimate it. A popular estimate for the survival function $S(t)$ is the [Kaplan–Meier estimate](http://en.wikipedia.org/wiki/Kaplan–Meier_estimator):\n",
     "\n",
-    "$$\\hat{S}(t)= \\prod_{ti < t} \\frac{n_i − d_i}{n_i}\\,,$$\n",
+    "\\begin{align*}\n",
+    "\\hat{S}(t) &= \\prod_{t_i \\leq t} \\frac{n_i − d_i}{n_i}\\,,\n",
+    "\\end{align*}\n",
     "\n",
     "where $d_i$ is the number of events (deaths) observed at time $t_i$ and $n_i$ is the number of subjects at risk observed at time $t_i$."
    ]

--- a/notebooks/survival_analysis/survival_analysis.py
+++ b/notebooks/survival_analysis/survival_analysis.py
@@ -79,7 +79,9 @@ get_ipython().magic(u'R install.packages("IOsurv")')
 # 
 # In practice, we do not get to observe the actual survival function of a population; we must use the observed data to estimate it. A popular estimate for the survival function $S(t)$ is the [Kaplan–Meier estimate](http://en.wikipedia.org/wiki/Kaplan–Meier_estimator):
 # 
-# $$\hat{S}(t)= \prod_{ti < t} \frac{n_i − d_i}{n_i}\,,$$
+# \begin{align*}
+# \hat{S}(t) &= \prod_{t_i \leq t} \frac{n_i − d_i}{n_i}\,,
+# \end{align*}
 # 
 # where $d_i$ is the number of events (deaths) observed at time $t_i$ and $n_i$ is the number of subjects at risk observed at time $t_i$.
 


### PR DESCRIPTION
Formula for the Kaplan–Meier estimate would also not render properly.

Generally speaking, using `\begin{align} ... \end{align}` seems more robust than `$$ ... $$`.

Still, it wouldn't render properly until I replaced subscript `t_i < t` with `t_i \leq t` (which leads to an alternate definition, see http://en.wikipedia.org/wiki/Kaplan%E2%80%93Meier_estimator#Formulation, so I would say it's okay).

/cc @etpinard @jackparmer @cldougl